### PR TITLE
Making message length messages clearer

### DIFF
--- a/nmf-view/frmMain.cs
+++ b/nmf-view/frmMain.cs
@@ -153,7 +153,7 @@ namespace nmf_view
                 }
 
                 Int32 cbBodyPromised = BitConverter.ToInt32(arrLenBytes, 0);
-                log($"Extension promised a message of length: {cbBodyPromised:N0}");
+                log($"Extension promised a message to app of length: {cbBodyPromised:N0}");
                 if (cbBodyPromised == 0)
                 {
                     log("Got an empty (size==0) message. Is that legal?? Disconnecting.");
@@ -246,7 +246,7 @@ namespace nmf_view
                 }
 
                 Int32 cbBodyPromised = BitConverter.ToInt32(arrLenBytes, 0);
-                log($"App promised a message of length: {cbBodyPromised:N0}");
+                log($"App promised a message to extension of length: {cbBodyPromised:N0}");
                 if (cbBodyPromised == 0)
                 {
                     log("Got an empty (size==0) message. Is that legal?? Disconnecting.");


### PR DESCRIPTION
Adding "to app" and "to extension" to the promised length messages. Not sure if it's just me, but it took me a little bit to realize what those messages were supposed to mean, and I think this makes the sender and receiver a little clearer.